### PR TITLE
Don't use send in Ruby

### DIFF
--- a/lib/biju/modem.rb
+++ b/lib/biju/modem.rb
@@ -48,7 +48,7 @@ module Biju
       cmd("AT+CMGD=#{id}")
     end
 
-    def send(sms, options = {})
+    def send_sms(sms, options = {})
       # initiate the sms, and wait for either
       # the text prompt or an error message
       cmd("AT+CMGS=\"#{sms.phone_number}\"")


### PR DESCRIPTION
Send is a special method

Object#send(:method) invokes the method identified by symbol

---

Hi there,

This fixes an error for me.  I was easily able to send and receive SMS with this, so thank you!
